### PR TITLE
Make work with 1.20

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,5 +5,5 @@
 # Learn more from ready-to-use templates: https://www.gitpod.io/docs/introduction/getting-started/quickstart
 
 tasks:
-  - init: sdk install java -y && npm install && gradle build
+  - init: sdk install java 17.0.7-amzn && npm install && gradle build
     command: npm run start

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,5 +5,5 @@
 # Learn more from ready-to-use templates: https://www.gitpod.io/docs/introduction/getting-started/quickstart
 
 tasks:
-  - init: Y | sdk install java 17.0.7-amzn && npm install && gradle build
+  - init: printf "Y" | sdk install java 17.0.7-amzn && npm install
     command: npm run start

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,5 +5,5 @@
 # Learn more from ready-to-use templates: https://www.gitpod.io/docs/introduction/getting-started/quickstart
 
 tasks:
-  - init: sdk install java 17.0.7-amzn && npm install && gradle build
+  - init: Y | sdk install java 17.0.7-amzn && npm install && gradle build
     command: npm run start

--- a/build-properties.js
+++ b/build-properties.js
@@ -13,7 +13,7 @@ async function start () {
   const [,, wantedVersion] = process.argv
   const yarnMappingsVersion = await getYarnMappingsVersion(wantedVersion)
   const fabricLoomVersion = await getFabricLoomVersion()
-  const text = `minecraft_version=${wantedVersion}\nyarn_mappings=${yarnMappingsVersion}\nfabric_loom_version=${fabricLoomVersion}`
+  const text = `minecraft_version=${wantedVersion}\nyarn_mappings=${yarnMappingsVersion}\nfabric_loom_version=${fabricLoomVersion}\norg.gradle.jvmargs=-Xmx4096m`
   await fs.writeFile('gradle.properties', text)
   console.info('Config file written.')
 }

--- a/src/main/java/mcextract/Main.java
+++ b/src/main/java/mcextract/Main.java
@@ -7,7 +7,8 @@ import net.minecraft.server.Bootstrap;
 import net.minecraft.SharedConstants;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.core.Registry;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.RangedAttribute;
 import net.minecraft.resources.ResourceLocation;
@@ -26,7 +27,6 @@ import java.lang.reflect.Field;
 public class Main {
 	public static String getGameVersion() {
 		return SharedConstants.getCurrentVersion().getName();
-		// return SharedConstants.VERSION_STRING;
 	}
 
 	public static String getArg(String[] args, String argName, String defaultValue) {
@@ -52,6 +52,7 @@ public class Main {
 	public static void main(String[] args) {
 		final boolean write = true;
 
+		SharedConstants.tryDetectVersion();
 		final String mcVersion = getGameVersion();
 		System.err.println("Initializing Minecraft " + mcVersion + " registries ...");
 		Bootstrap.bootStrap();
@@ -154,7 +155,7 @@ public class Main {
 		final JsonObject allBlocksJson = new JsonObject();
 		final HashMap<Shape, Integer> shapeIds = new HashMap<>();
 
-		for (final Block block : Registry.BLOCK) {
+		for (final Block block : BuiltInRegistries.BLOCK) {
 			final ImmutableList<BlockState> states = block.getStateDefinition().getPossibleStates();
 			final int[] boxesByState = new int[states.size()];
 
@@ -201,7 +202,7 @@ public class Main {
 
 	private static ArrayList<String> runSanityChecks(BlockCollisionBoxStorage storage) {
 		final ArrayList<String> failures = new ArrayList<>();
-		for (final Block block : Registry.BLOCK) {
+		for (final Block block : BuiltInRegistries.BLOCK) {
 			final String blockId = getBlockIdString(block);
 			final ImmutableList<BlockState> states = block.getStateDefinition().getPossibleStates();
 			for (int stateId = 0; stateId < states.size(); stateId++) {
@@ -225,7 +226,7 @@ public class Main {
 	}
 
 	private static String getBlockIdString(Block block) {
-		final String blockId = Integer.toString(Registry.BLOCK.getId(block));
+		final String blockId = Integer.toString(BuiltInRegistries.BLOCK.getId(block));
 		if (!blockId.startsWith("minecraft:")) return blockId;
 		return blockId.replaceAll("^minecraft:", "");
 	}
@@ -233,7 +234,7 @@ public class Main {
 	// ATTRIBUTES
 	public static JsonObject extractAttributes() {
 		final JsonObject allAttributes = new JsonObject();
-		for (Attribute attr : Registry.ATTRIBUTE) {
+		for (Attribute attr : BuiltInRegistries.ATTRIBUTE) {
 			final JsonObject attrJson = new JsonObject();
 			attrJson.addProperty("default", attr.getDefaultValue());
 			if (attr instanceof RangedAttribute) {
@@ -244,13 +245,13 @@ public class Main {
 				attrJson.addProperty("max", maxVal);
 			}
 
-			ResourceLocation key = Registry.ATTRIBUTE.getKey(attr);
+			ResourceLocation key = BuiltInRegistries.ATTRIBUTE.getKey(attr);
 			if (key == null) {
 				System.err.println("ERROR: attribute has no key: " + attr);
 				continue;
 			}
 			attrJson.addProperty("description", attr.getDescriptionId());
-			attrJson.addProperty("id", Registry.ATTRIBUTE.getId(attr));
+			attrJson.addProperty("id", BuiltInRegistries.ATTRIBUTE.getId(attr));
 			allAttributes.add(key.toString(), attrJson);
 		}
 		return allAttributes;


### PR DESCRIPTION
Some changes were needed to keep compatibility with the latest Minecraft API

Additionally, I made it automatically allocate more memory to the heap when it generates the gradle.properties as it was running out of memory computing the mappings.

I also made it work with GitPod and the latest SDKMAN to automatically install Java 17 (which was failing previously due to the "-y"  being used as the Java version and removed the redundant automatic run of "gradle build" as it couldn't build due to `npm run start` not being used yet.
